### PR TITLE
Amend description & tagline phrasing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Resonate Documentation',
-  tagline: 'Documentation for the tech behind the co-operative music streaming service',
+  tagline: 'Documenting the tech behind the co-operative music streaming service',
   url: 'https://resonate.coop',
   baseUrl: '/',
   onBrokenLinks: 'warn',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={siteConfig.title}
-      description="Documentation for the tech behind the co-operative music streaming service">
+      description="Documenting the tech behind the co-operative music streaming service">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
Changes the `description` and `tagline` to:
> Documenting the tech behind the co-operative music streaming service